### PR TITLE
Add sticky header component

### DIFF
--- a/ai-chat-bot/src/App.css
+++ b/ai-chat-bot/src/App.css
@@ -1,7 +1,7 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 4rem 2rem 2rem;
   text-align: center;
 }
 

--- a/ai-chat-bot/src/App.jsx
+++ b/ai-chat-bot/src/App.jsx
@@ -1,11 +1,11 @@
 import FloatingSidebar from './components/FloatingSidebar.jsx'
+import Header from './components/Header.jsx'
 
 function App() {
-
   return (
     <>
+      <Header />
       <FloatingSidebar />
-
       <main>Main</main>
       <footer>footer component</footer>
     </>

--- a/ai-chat-bot/src/components/Header.css
+++ b/ai-chat-bot/src/components/Header.css
@@ -1,0 +1,49 @@
+.app-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background-color: #242424;
+  z-index: 1000;
+}
+
+.logo-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.logo-wrapper img {
+  height: 32px;
+  width: 32px;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-item {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  font: inherit;
+  border-bottom: 2px solid transparent;
+}
+
+.nav-item.active {
+  border-color: #646cff;
+}
+
+.user-icon {
+  font-size: 1.5rem;
+}

--- a/ai-chat-bot/src/components/Header.jsx
+++ b/ai-chat-bot/src/components/Header.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import logo from '../assets/react.svg'
+import './Header.css'
+
+function Header() {
+  const [active, setActive] = useState('Home')
+  const menuItems = ['Home', 'Features', 'Pricing', 'Contact']
+
+  return (
+    <header className="app-header">
+      <div className="logo-wrapper">
+        <img src={logo} alt="AI Chat Bot Logo" />
+        <span className="logo-text">AI Chat Bot</span>
+      </div>
+      <nav>
+        <ul>
+          {menuItems.map((item) => (
+            <li key={item}>
+              <button
+                className={active === item ? 'nav-item active' : 'nav-item'}
+                onClick={() => setActive(item)}
+              >
+                {item}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="user-icon" title="User">
+        \u{1F464}
+      </div>
+    </header>
+  )
+}
+
+export default Header


### PR DESCRIPTION
## Summary
- create `Header` component with AI chat bot logo, navigation items, active highlighting and user icon
- include header component in `App`
- add styles for sticky header
- pad root so content isn't hidden

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b01f527c83289993d5d8681c1d81