### PR TITLE
Add simple React chat bot screen

### DIFF
--- a/ai-chat-bot/src/App.jsx
+++ b/ai-chat-bot/src/App.jsx
@@ -3,13 +3,14 @@ import Header from './components/Header.jsx'
 import FarmerIntro from './components/FarmerIntro.jsx'
 import ContactForm from './components/ContactForm.jsx'
 import DeliveryInstructions from './components/DeliveryInstructions.jsx'
+import ChatBot from './components/ChatBot.jsx'
 
 function App() {
   return (
     <>
       <Header />
       <main>
-        Main
+        <ChatBot />
       </main>
       <footer>Fresh Microgreens &copy; 2024</footer>
     </>

--- a/ai-chat-bot/src/api/chatService.js
+++ b/ai-chat-bot/src/api/chatService.js
@@ -1,0 +1,11 @@
+import responses from './responses.json'
+
+export function fetchBotReply(message) {
+  const entry = responses.find(
+    (r) => r.user.toLowerCase() === message.toLowerCase(),
+  )
+  const reply = entry ? entry.bot : "I'm not sure how to respond to that."
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(reply), 500)
+  })
+}

--- a/ai-chat-bot/src/api/responses.json
+++ b/ai-chat-bot/src/api/responses.json
@@ -1,0 +1,5 @@
+[
+  { "user": "hello", "bot": "Hi! How can I assist you today?" },
+  { "user": "what's your name", "bot": "I'm your friendly chat bot." },
+  { "user": "bye", "bot": "Goodbye!" }
+]

--- a/ai-chat-bot/src/components/ChatBot.css
+++ b/ai-chat-bot/src/components/ChatBot.css
@@ -1,0 +1,37 @@
+.chatbot {
+  border: 1px solid #ccc;
+  max-width: 400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  height: 400px;
+}
+
+.chat-window {
+  flex: 1;
+  padding: 0.5rem;
+  overflow-y: auto;
+}
+
+.chat-message {
+  margin-bottom: 0.5rem;
+}
+
+.chat-message.user {
+  text-align: right;
+}
+
+.chat-input {
+  display: flex;
+  border-top: 1px solid #ccc;
+}
+
+.chat-input input {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+}
+
+.chat-input button {
+  padding: 0.5rem 1rem;
+}

--- a/ai-chat-bot/src/components/ChatBot.jsx
+++ b/ai-chat-bot/src/components/ChatBot.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { fetchBotReply } from '../api/chatService'
+import './ChatBot.css'
+
+function ChatBot() {
+  const [messages, setMessages] = useState([])
+  const [input, setInput] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const text = input.trim()
+    if (!text) return
+    setInput('')
+    setMessages((msgs) => [...msgs, { from: 'user', text }])
+    const reply = await fetchBotReply(text)
+    setMessages((msgs) => [...msgs, { from: 'bot', text: reply }])
+  }
+
+  return (
+    <div className="chatbot">
+      <div className="chat-window">
+        {messages.map((msg, idx) => (
+          <div key={idx} className={`chat-message ${msg.from}`}>
+            {msg.text}
+          </div>
+        ))}
+      </div>
+      <form className="chat-input" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type your message..."
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  )
+}
+
+export default ChatBot


### PR DESCRIPTION
## Summary
- integrate a basic ChatBot component
- implement a dummy chat API returning replies from a local JSON file
- show the chat bot in the main app

## Testing
- `npm run lint` *(fails: Cannot find package 'globals' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6870de8512048328998a0bd5ec653a55